### PR TITLE
[SuperUrlBar] Add support for hiding Hover Zoom+ add-on icon

### DIFF
--- a/SuperUrlBar/SuperUrlBar.css
+++ b/SuperUrlBar/SuperUrlBar.css
@@ -166,6 +166,12 @@
       opacity: 1;
     } 
   }
+  @media (-moz-bool-pref: "uc.urlbar.icon.hover-zoom.removed") {
+    #urlbar:hover .urlbar-page-action.urlbar-addon-page-action[aria-label="Hover Zoom+"] {
+      position: relative;
+      opacity: 1;
+    }
+  }
   @media (-moz-bool-pref: "uc.urlbar.icon.container.removed") {
     #urlbar:hover #userContext-icons {
       position: relative;
@@ -211,6 +217,13 @@
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.pip.removed") {
   #picture-in-picture-button {
+    opacity: 0;
+    position: var(--position-var);
+    transition: 100ms linear, opacity 200ms linear;
+  }
+}
+@media (-moz-bool-pref: "uc.urlbar.icon.hover-zoom.removed") {
+  .urlbar-page-action.urlbar-addon-page-action[aria-label="Hover Zoom+"] {
     opacity: 0;
     position: var(--position-var);
     transition: 100ms linear, opacity 200ms linear;

--- a/SuperUrlBar/preferences.json
+++ b/SuperUrlBar/preferences.json
@@ -121,6 +121,12 @@
         "disabledOn": []
     },
     {
+        "property": "uc.urlbar.icon.hover-zoom.removed",
+        "label": "Hides the Hover Zoom+ icon",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "uc.urlbar.icon.container.removed",
         "label": "Hides the Container Tab icon and text",
         "type": "checkbox",


### PR DESCRIPTION
Hide URL icon from [Hover Zoom+](https://github.com/extesy/hoverzoom/) add-on.

I have all of the other icons hidden until hovered and this one sticks out:

![image](https://github.com/user-attachments/assets/de4c0772-9bc9-4e30-9414-dc9924c0d6e0)

Let me know if I should make a PR to the theme-store directly adding you as a reviewer, or if this is not even a good idea. Unfortunately the icon from the add-on does not have a class/id to target it directly. 

Tested with inline CSS and it works:

![hoverzoom](https://github.com/user-attachments/assets/56453c05-8c00-45b3-ace8-836c039691ea)

