### PR TITLE
fix: hide inactive workspaces

### DIFF
--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -8,6 +8,12 @@
     }
 
     @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) {
+        
+        /* Hide inactive workspaces */
+        .zen-workspace-tabs-section[hidden="true"],
+        .zen-workspace-tabs-section:not([active="true"]) {
+            visibility: hidden;
+        }
 
         /* Set width of Essentials (Dropdown) */
         :root:has(#theme-SuperPins[uc-essentials-width="Thin"]) {


### PR DESCRIPTION
this fixes the background/border of pins bleeding into other workspaces, closes #88.

before: 
![image](https://github.com/user-attachments/assets/fb59efd4-4d86-4e36-9bd6-33dbe95ceab3)

after: 
![image](https://github.com/user-attachments/assets/7cc7d4b1-0b34-423e-ad0b-bc9bf011d4c4)
