### PR TITLE
feat: add support for custom pinned tab heights, pinned tab favicon size and workspace icon

### DIFF
--- a/SuperPins/README.md
+++ b/SuperPins/README.md
@@ -15,8 +15,8 @@ This **Zen Mod** elevates your experience with pinned tabs and Essentials by mak
   - Hide the workspace indicator between Essentials and Pins
   - Load pinned tabs only when using them, instead of loading all of them on startup
   - Dim unloaded tabs
-  - Customize height of Essentials tabs (Small, Normal, Large)
-  - Adjust Essential icons size (Small, Normal, Large)
+  - Customize height of Pinned tabs (Small, Normal, Large)
+  - Adjust Pinned icons size (Small, Normal, Large)
   - Change workspace icons size (Extra Small, Small, Medium, Large)
   - Control the current workspace indicator icon size (Small, Normal, Large)
 

--- a/SuperPins/README.md
+++ b/SuperPins/README.md
@@ -16,7 +16,7 @@ This **Zen Mod** elevates your experience with pinned tabs and Essentials by mak
   - Load pinned tabs only when using them, instead of loading all of them on startup
   - Dim unloaded tabs
   - Customize height of Pinned tabs (Small, Normal, Large)
-  - Adjust Pinned icons size (Small, Normal, Large)
+  - Adjust tab favicon size (Small, Normal, Large)
   - Change workspace icons size (Extra Small, Small, Medium, Large)
   - Control the current workspace indicator icon size (Small, Normal, Large)
 

--- a/SuperPins/README.md
+++ b/SuperPins/README.md
@@ -15,3 +15,8 @@ This **Zen Mod** elevates your experience with pinned tabs and Essentials by mak
   - Hide the workspace indicator between Essentials and Pins
   - Load pinned tabs only when using them, instead of loading all of them on startup
   - Dim unloaded tabs
+  - Customize height of Essentials tabs (Small, Normal, Large)
+  - Adjust Essential icons size (Small, Normal, Large)
+  - Change workspace icons size (Extra Small, Small, Medium, Large)
+  - Control the current workspace indicator icon size (Small, Normal, Large)
+

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -191,7 +191,7 @@
 
     
     /* essentials height */
-    :root:has(#theme-SuperPins[uc-essentials-height="small"]) {
+    :root:has(#theme-SuperPins[uc-pinned-height="small"]) {
         #navigator-toolbox[zen-sidebar-expanded="true"]
             #vertical-pinned-tabs-container:has(tab:not([hidden]))
             .tabbrowser-tab {
@@ -199,7 +199,7 @@
         }
     }
 
-    :root:has(#theme-SuperPins[uc-essentials-height="normal"]) {
+    :root:has(#theme-SuperPins[uc-pinned-height="normal"]) {
         #navigator-toolbox[zen-sidebar-expanded="true"]
             #vertical-pinned-tabs-container:has(tab:not([hidden]))
             .tabbrowser-tab {
@@ -207,7 +207,7 @@
         }
     }
 
-    :root:has(#theme-SuperPins[uc-essentials-height="large"]) {
+    :root:has(#theme-SuperPins[uc-pinned-height="large"]) {
         #navigator-toolbox[zen-sidebar-expanded="true"]
             #vertical-pinned-tabs-container:has(tab:not([hidden]))
             .tabbrowser-tab {
@@ -216,7 +216,7 @@
     }
 
     /* essential icons size */
-    :root:has(#theme-SuperPins[uc-essentials-icon-size="small"]) {
+    :root:has(#theme-SuperPins[uc-pinned-icon-size="small"]) {
         .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
@@ -227,7 +227,7 @@
         }
     }
 
-    :root:has(#theme-SuperPins[uc-essentials-icon-size="normal"]) {
+    :root:has(#theme-SuperPins[uc-pinned-icon-size="normal"]) {
         .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
@@ -238,7 +238,7 @@
         }
     }
 
-    :root:has(#theme-SuperPins[uc-essentials-icon-size="large"]) {
+    :root:has(#theme-SuperPins[uc-pinned-icon-size="large"]) {
         .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -188,4 +188,108 @@
             gap: var(--essentials-gap) var(--essentials-gap) !important;
         }
     }
+
+    
+    /* essentials height */
+    :root:has(#theme-SuperPins[uc-essentials-height="small"]) {
+        #navigator-toolbox[zen-sidebar-expanded="true"]
+            #vertical-pinned-tabs-container:has(tab:not([hidden]))
+            .tabbrowser-tab {
+            height: 40px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-essentials-height="normal"]) {
+        #navigator-toolbox[zen-sidebar-expanded="true"]
+            #vertical-pinned-tabs-container:has(tab:not([hidden]))
+            .tabbrowser-tab {
+            height: 50px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-essentials-height="large"]) {
+        #navigator-toolbox[zen-sidebar-expanded="true"]
+            #vertical-pinned-tabs-container:has(tab:not([hidden]))
+            .tabbrowser-tab {
+            height: 60px !important;
+        }
+    }
+
+    /* essential icons size */
+    :root:has(#theme-SuperPins[uc-essentials-icon-size="small"]) {
+        .tab-throbber,
+        .tab-icon-pending,
+        .tab-icon-image,
+        .tab-sharing-icon-overlay,
+        .tab-icon-overlay {
+            height: 16px !important;
+            width: 16px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-essentials-icon-size="normal"]) {
+        .tab-throbber,
+        .tab-icon-pending,
+        .tab-icon-image,
+        .tab-sharing-icon-overlay,
+        .tab-icon-overlay {
+            height: 18px !important;
+            width: 18px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-essentials-icon-size="large"]) {
+        .tab-throbber,
+        .tab-icon-pending,
+        .tab-icon-image,
+        .tab-sharing-icon-overlay,
+        .tab-icon-overlay {
+            height: 20px !important;
+            width: 20px !important;
+        }
+    }
+
+    /* workspace icons size */
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="x-small"]) {
+        #zen-workspaces-button {
+            font-size: x-small !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="small"]) {
+        #zen-workspaces-button {
+            font-size: small !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="medium"]) {
+        #zen-workspaces-button {
+            font-size: medium !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="large"]) {
+        #zen-workspaces-button {
+            font-size: large !important;
+        }
+    }
+
+    /* current workspace icons size */
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="small"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 12px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="normal"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 14.5px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="large"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 16px !important;
+        }
+    }
 }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -215,8 +215,8 @@
         }
     }
 
-    /* pins icons size */
-    :root:has(#theme-SuperPins[uc-pinned-icon-size="small"]) {
+    /* favicon size */
+    :root:has(#theme-SuperPins[uc-favicon-size="small"]) {
         .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
@@ -227,7 +227,7 @@
         }
     }
 
-    :root:has(#theme-SuperPins[uc-pinned-icon-size="normal"]) {
+    :root:has(#theme-SuperPins[uc-favicon-size="normal"]) {
         .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
@@ -238,7 +238,7 @@
         }
     }
 
-    :root:has(#theme-SuperPins[uc-pinned-icon-size="large"]) {
+    :root:has(#theme-SuperPins[uc-favicon-size="large"]) {
         .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -91,13 +91,13 @@
             gap: 3px !important;
         }
 
-        /*Somewhat fixes the bleeding of pins from other workspaces*/
+        /* WIP Somewhat fixes the bleeding of pins from other workspaces
         #vertical-pinned-tabs-container > .zen-workspace-tabs-section[active] {
             visibility: visible;
         } 
         #vertical-pinned-tabs-container > .zen-workspace-tabs-section[hidden]{
             visibility: hidden;
-        }
+        }*/
 
         #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
             --toolbarbutton-inner-padding: 0;
@@ -190,7 +190,7 @@
     }
 
     
-    /* essentials height */
+    /* pins height */
     :root:has(#theme-SuperPins[uc-pinned-height="small"]) {
         #navigator-toolbox[zen-sidebar-expanded="true"]
             #vertical-pinned-tabs-container:has(tab:not([hidden]))
@@ -215,7 +215,7 @@
         }
     }
 
-    /* essential icons size */
+    /* pins icons size */
     :root:has(#theme-SuperPins[uc-pinned-icon-size="small"]) {
         .tab-throbber,
         .tab-icon-pending,

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -120,8 +120,8 @@
         "disabledOn": []
     },
     {
-        "property": "uc.essentials.height",
-        "label": "Height of Essentials tabs",
+        "property": "uc.pinned.height",
+        "label": "Height of Pinned tabs",
         "type": "dropdown",
         "placeholder": "Default",
         "options": [
@@ -140,8 +140,8 @@
         ]
     },
     {
-        "property": "uc.essentials.icon.size",
-        "label": "Size of Essential icons",
+        "property": "uc.pinned.icon.size",
+        "label": "Size of Pinned icons",
         "type": "dropdown",
         "placeholder": "Default",
         "options": [

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -118,5 +118,89 @@
         "label": "Dims unloaded tabs",
         "type": "checkbox",
         "disabledOn": []
+    },
+    {
+        "property": "uc.essentials.height",
+        "label": "Height of Essentials tabs",
+        "type": "dropdown",
+        "placeholder": "Default",
+        "options": [
+            {
+                "label": "Small",
+                "value": "small"
+            },
+            {
+                "label": "Normal",
+                "value": "normal"
+            },
+            {
+                "label": "Large",
+                "value": "large"
+            }
+        ]
+    },
+    {
+        "property": "uc.essentials.icon.size",
+        "label": "Size of Essential icons",
+        "type": "dropdown",
+        "placeholder": "Default",
+        "options": [
+            {
+                "label": "Small",
+                "value": "small"
+            },
+            {
+                "label": "Normal",
+                "value": "normal"
+            },
+            {
+                "label": "Large",
+                "value": "large"
+            }
+        ]
+    },
+    {
+        "property": "uc.workspace.icon.size",
+        "label": "Size of workspace icons",
+        "type": "dropdown",
+        "placeholder": "Default",
+        "options": [
+            {
+                "label": "Extra Small",
+                "value": "x-small"
+            },
+            {
+                "label": "Small",
+                "value": "small"
+            },
+            {
+                "label": "Medium",
+                "value": "medium"
+            },
+            {
+                "label": "Large",
+                "value": "large"
+            }
+        ]
+    },
+    {
+        "property": "uc.workspace.current.icon.size",
+        "label": "Size of current workspace indicator icon",
+        "type": "dropdown",
+        "placeholder": "Default",
+        "options": [
+            {
+                "label": "Small",
+                "value": "small"
+            },
+            {
+                "label": "Normal",
+                "value": "normal"
+            },
+            {
+                "label": "Large",
+                "value": "large"
+            }
+        ]
     }
 ]

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -140,8 +140,8 @@
         ]
     },
     {
-        "property": "uc.pinned.icon.size",
-        "label": "Size of Pinned icons",
+        "property": "uc.favicon.size",
+        "label": "Size of tabs favicons",
         "type": "dropdown",
         "placeholder": "Default",
         "options": [


### PR DESCRIPTION
## Description
This adds new customization options to the SuperPins mod, allowing users to control various UI element sizes. The changes include new dropdown preferences for adjusting the dimensions of Pinned tabs, icons, and workspace indicators.

### New Features
- Added height control for Pinned tabs (Small: 40px, Normal: 50px, Large: 60px)
- Added size control for Pinned icons (Small: 16px, Normal: 18px, Large: 20px)
- Added workspace icons size options (x-small, small, medium, large)
- Added current workspace indicator size control (Small: 12px, Normal: 14.5px, Large: 16px)

## Testing Done
- Verified each size option works correctly
- Tested compatibility with existing features
- Ensured default values work properly when preferences are not set

## Screenshots
### Settings
<img width="823" alt="image" src="https://github.com/user-attachments/assets/9d277194-24ad-4c23-8238-04978c020f87" />

### Before
<img width="166" alt="image" src="https://github.com/user-attachments/assets/5d3a621b-d2e6-46f9-930a-5f32937ee9e4" />
<img width="162" alt="image" src="https://github.com/user-attachments/assets/269556db-9ada-4ac5-9e41-f45f21aaca78" />


### After
<img width="164" alt="image" src="https://github.com/user-attachments/assets/10b638a7-4db7-4327-aea0-45b0a86a3681" />
<img width="174" alt="image" src="https://github.com/user-attachments/assets/fe75a662-7069-4fc8-8d34-d35530afb049" />
