### PR TITLE
Added option for line-through on unloaded tabs, added custom grid sizes for Essentials and Pinned Tabs, added margin below Essentials, added dropdown for occasion to show separator, added option to keep pinned tabs at the top, improved Super Url Bar, added option to have custom background for active pinned tabs, fixed duplicate of tab throbber, fixed Twilight zen-essentials-container issues, fixed split tabs display bug inside of pinned tabs when auto-grow is on, and improved stability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+> [!Note]
+> This repository is no longer actively mantained. However development on the "SuperPins" Mod will continue thanks to [@CosmoCreeper](https://github.com/CosmoCreeper) in the following repository: https://github.com/CosmoCreeper/Zen-Themes. Be sure to give him a star if you like the mod!
+
 # Zen Themes
 
 A personal collection of my CSS Themes 🎨 for the [Zen Browser](https://zen-browser.app/).
-
-(This repo probably won't get any new changes in the future. However, everyone's welcome to fork the repo/create a new one and make changes and all as well as submiting these changes to the official Zen Mods repo, no need to ask me or create a pr here 👍)
 
 ## Currently there is 1 Mod available to be installed through [Zen's website](https://zen-browser.app/mods):
   - [**SuperPins**](https://zen-browser.app/mods/ad97bb70-0066-4e42-9b5f-173a5e42c6fc)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A personal collection of my CSS Themes 🎨 for the [Zen Browser](https://zen-br
 
 (This repo probably won't get any new changes in the future. However, everyone's welcome to fork the repo/create a new one and make changes and all as well as submiting these changes to the official Zen Mods repo, no need to ask me or create a pr here 👍)
 
-## Currently there is 1 Mod available to be installed through [Zen's website](https://zen-browser.app/themes):
-  - [**SuperPins**](https://zen-browser.app/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc)
+## Currently there is 1 Mod available to be installed through [Zen's website](https://zen-browser.app/mods):
+  - [**SuperPins**](https://zen-browser.app/mods/ad97bb70-0066-4e42-9b5f-173a5e42c6fc)
 
 ![image](https://raw.githubusercontent.com/JLBlk/Zen-Themes/refs/heads/main/SuperPins/image.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!Note]
-> This repository is no longer actively mantained. However development on the "SuperPins" Mod will continue thanks to [@CosmoCreeper](https://github.com/CosmoCreeper) in the following repository: https://github.com/CosmoCreeper/Zen-Themes. Be sure to give him a star if you like the mod!
-
 # Zen Themes
 
 A personal collection of my CSS Themes 🎨 for the [Zen Browser](https://zen-browser.app/).

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -463,6 +463,7 @@
       
       #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
           overflow-y: auto !important;
+          overflow-x: hidden !important;
           /* Calculate the height of the bottom workspace section. */
           max-height: calc(100% - 43px) !important;
           box-sizing: border-box !important;

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -1,4 +1,8 @@
 @media (-moz-bool-pref: "zen.tabs.vertical") {
+    /* Prevents stuff from being clipped off from bottom of Essentials */
+    #zen-essentials-container {
+        overflow: visible !important;
+    }
     
     /* Makes essentials transparent (when toggled) */
     :root:has(#theme-SuperPins[uc-essentials-color-scheme="transparent"]) {

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -329,7 +329,6 @@
     /* favicon size */
     :root:has(#theme-SuperPins[uc-favicon-size="small"]) {
 
-        .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
         .tab-sharing-icon-overlay,
@@ -337,11 +336,12 @@
             height: 16px !important;
             width: 16px !important;
         }
+
+        /* No need to scale tab throbber as it is same size. */
     }
 
     :root:has(#theme-SuperPins[uc-favicon-size="normal"]) {
 
-        .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
         .tab-sharing-icon-overlay,
@@ -349,17 +349,24 @@
             height: 18px !important;
             width: 18px !important;
         }
+
+        .tab-throbber[busy] {
+            transform: scale(1.125) !important;
+        }
     }
 
     :root:has(#theme-SuperPins[uc-favicon-size="large"]) {
 
-        .tab-throbber,
         .tab-icon-pending,
         .tab-icon-image,
         .tab-sharing-icon-overlay,
         .tab-icon-overlay {
             height: 20px !important;
             width: 20px !important;
+        }
+
+        .tab-throbber[busy] {
+            transform: scale(1.25) !important;
         }
     }
 
@@ -502,6 +509,18 @@
         /* Ensure tab-groups never shrink. */
         tab-group {
             flex: 0 0 auto !important;
+        }
+    }
+
+    @media (-moz-bool-pref: "uc.pins.active-bg") {
+        .zen-workspace-tabs-section .tabbrowser-tab[pinned][selected="true"] .tab-stack .tab-background {
+            background-color: var(--mod-superpins-pins-active-bg) !important;
+            opacity: 1 !important;
+        }
+
+        .zen-workspace-tabs-section .tabbrowser-tab[pinned][selected="true"]:hover .tab-stack .tab-background {
+            opacity: 0.8 !important;
+            background-color: var(--mod-superpins-pins-active-bg) !important;
         }
     }
 }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -129,7 +129,7 @@
 
             @media (-moz-bool-pref: "uc.pins.grid-count") {
                 #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
-                    grid-template-columns: repeat(var(--mod-superpins-pins-grid-count), minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
+                    grid-template-columns: repeat(var(auto-fit, --mod-superpins-pins-grid-count), minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
                 }
             }
         }
@@ -297,7 +297,7 @@
 
         @media (-moz-bool-pref: "uc.pins.grid-count") {
             #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
-                grid-template-columns: repeat(var(--mod-superpins-pins-grid-count), minmax(var(--essentials-width), auto)) !important;
+                grid-template-columns: repeat(var(auto-fit, --mod-superpins-pins-grid-count), minmax(var(--essentials-width), auto)) !important;
             }
         }
     }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -137,9 +137,10 @@
         /*The actual grid layout*/
         #vertical-pinned-tabs-container>.zen-workspace-tabs-section:has(> :nth-child(2)) {
             padding: 0 var(--zen-toolbox-padding) !important;
-            overflow: hidden !important;
+            overflow: visible !important;
             padding-bottom: 17px !important;
             gap: 3px 3px !important;
+            max-width: calc(100% - var(--zen-toolbox-padding) * 2) !important;
         }
 
         #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -1,7 +1,7 @@
 @media (-moz-bool-pref: "zen.tabs.vertical") {
 
     /* Prevents stuff from being clipped off from bottom of Essentials */
-    #zen-essentials-container {
+    #zen-essentials-container, .zen-essentials-container {
         overflow: visible !important;
     }
 
@@ -36,14 +36,17 @@
         :root:has(#theme-SuperPins[uc-essentials-width="Thin"],
             #theme-SuperPins[uc-essentials-width="Normal"],
             #theme-SuperPins[uc-essentials-width="Wide"]) {
-            #zen-essentials-container {
+            #zen-essentials-container, .zen-essentials-container {
                 grid-template-columns: repeat(auto-fit,
                         minmax(var(--essentials-width), auto)) !important;
-                min-width: var(--essentials-width) !important;
+            }
+
+            .zen-essentials-container {
+                max-width: calc(100% - var(--zen-toolbox-padding) * 2);
             }
 
             @media (-moz-bool-pref: "uc.essentials.grid-count") {
-                #zen-essentials-container {
+                #zen-essentials-container, .zen-essentials-container {
                     grid-template-columns: repeat(var(--mod-superpins-essentials-grid-count), minmax(var(--essentials-width), auto)) !important;
                 }
             }
@@ -65,7 +68,7 @@
         :root:has(#theme-SuperPins[uc-essentials-gap="Small"],
             #theme-SuperPins[uc-essentials-gap="Normal"],
             #theme-SuperPins[uc-essentials-gap="Big"]) {
-            #zen-essentials-container {
+            #zen-essentials-container, .zen-essentials-container {
                 gap: var(--essentials-gap) var(--essentials-gap) !important;
             }
         }
@@ -182,7 +185,7 @@
 
     /* If Essentials have a grid count but do not have auto-grow on */
     @media (-moz-bool-pref: "uc.essentials.grid-count") {
-        #zen-essentials-container {
+        #zen-essentials-container, .zen-essentials-container {
             grid-template-columns: repeat(var(--mod-superpins-essentials-grid-count), minmax(var(--essentials-width), auto)) !important;
         }
     }
@@ -203,7 +206,7 @@
             }
         }
 
-        #zen-essentials-container {
+        #zen-essentials-container, .zen-essentials-container {
             display: flex !important;
             flex-wrap: wrap !important;
             flex-direction: row !important;
@@ -217,7 +220,7 @@
 
     /* Puts Essentials at the bottom */
     :has(#theme-SuperPins[uc-essentials-position="bottom"]) {
-        #zen-essentials-container {
+        #zen-essentials-container, .zen-essentials-container {
             order: 999 !important;
             margin-top: auto !important;
             padding-top: 5px !important;
@@ -264,9 +267,11 @@
 
     /* Adds border to Pins/Essentials (when toggled) */
     :root:has(#theme-SuperPins[uc-superpins-border="essentials"]) {
-        #zen-essentials-container .tabbrowser-tab[zen-essential="true"] .tab-stack .tab-background {
-            border: 1px solid light-dark(color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
-                    color-mix(in srgb, var(--zen-colors-secondary) 80%, white)) !important;
+        #zen-essentials-container, .zen-essentials-container {
+            & .tabbrowser-tab[zen-essential="true"] .tab-stack .tab-background {
+                border: 1px solid light-dark(color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
+                        color-mix(in srgb, var(--zen-colors-secondary) 80%, white)) !important;
+            }
         }
     }
 
@@ -414,29 +419,30 @@
         }
     }
 
-    /* prevents bottom portion of essentials element from being cut off. */
-    #zen-essentials-container {
-        padding: unset !important;
-    }
-
     /* Increase margin below Essentials in case the workspace indicator is not visible. */
     @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
         :root:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"]) {
-            #zen-essentials-container:has(~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container .zen-workspace-tabs-section[active="true"] .tabbrowser-tab) {
-                margin-bottom: 8px !important;
+            #zen-essentials-container, .zen-essentials-container {
+                &:has(~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container .zen-workspace-tabs-section[active="true"] .tabbrowser-tab) {
+                    margin-bottom: 8px !important;
+                }
             }
 
-            #zen-essentials-container:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
-                min-height: 20px !important;
+            #zen-essentials-container, .zen-essentials-container {
+                &:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+                    min-height: 20px !important;
+                }
             }
 
-            #zen-essentials-container:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section .vertical-pinned-tabs-container-separator {
-                max-height: unset !important;
+            #zen-essentials-container, .zen-essentials-container {
+                &:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section .vertical-pinned-tabs-container-separator {
+                    max-height: unset !important;
+                }
             }
         }
 
         :root:not(:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"])) {
-            #zen-essentials-container {
+            #zen-essentials-container, .zen-essentials-container {
                 margin-bottom: 8px !important;
             }
         }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -397,20 +397,26 @@
     padding: unset !important;
   }
 
-  /* margin below essentials */
-  :root:has(#theme-Superpins[uc-essentials-bottom-margin="small"]) {
-      #zen-essentials-container {
-          margin-bottom: 3px !important;
+  /* Increase margin below Essentials in case the workspace indicator is not visible. */
+  @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
+      :root:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"]) {
+          #zen-essentials-container:has(~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container .zen-workspace-tabs-section[active="true"] .tabbrowser-tab) {
+              margin-bottom: 8px !important;
+          }
+
+          #zen-essentials-container:has(> :nth-child(1)) ~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+              min-height: 20px !important;
+          }
+
+          #zen-essentials-container:has(> :nth-child(1)) ~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section .vertical-pinned-tabs-container-separator {
+              max-height: unset !important;
+          }
       }
-  }
-  :root:has(#theme-SuperPins[uc-essentials-bottom-margin="normal"]) {
-      #zen-essentials-container {
-          margin-bottom: 8px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-essentials-bottom-margin="large"]) {
-      #zen-essentials-container {
-          margin-bottom: 12px !important;
+
+      :root:not(:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"])) {
+          #zen-essentials-container {
+              margin-bottom: 8px !important;
+          }
       }
   }
 
@@ -446,44 +452,38 @@
     }
   }
 
-  :root:has(#theme-SuperPins[uc-tabs-show-separator="always"]) {
-    #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
-        min-height: 20px !important;
-    }
-  }
-
   @media (-moz-bool-pref: "uc.pins.stay-at-top") {
-      #zen-browser-tabs-container {
-          height: 100% !important;
-      }
-      
-      #tabbrowser-arrowscrollbox {
-          height: 100% !important;
-      }
-      
-      #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
-          overflow-y: auto !important;
-          overflow-x: hidden !important;
-          /* Calculate the height of the bottom workspace section. */
-          max-height: calc(100% - 43px) !important;
-          box-sizing: border-box !important;
-          padding-bottom: 60px !important;
-      }
-      
-      /* In case workspace indicator is not visible. */
-      @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
-          #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
-              max-height: calc(100% - 5px) !important;
-          }
-      }
-      
-      #zen-tabs-wrapper {
-          overflow: hidden !important;
-      }
-      
-      /* Ensure tab-groups never shrink. */
-      tab-group {
-          flex: 0 0 auto !important;
-      }
+    #zen-browser-tabs-container {
+        height: 100% !important;
+    }
+    
+    #tabbrowser-arrowscrollbox {
+        height: 100% !important;
+    }
+    
+    #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
+        overflow-y: auto !important;
+        overflow-x: hidden !important;
+        /* Calculate the height of the bottom workspace section. */
+        max-height: calc(100% - 43px) !important;
+        box-sizing: border-box !important;
+        padding-bottom: 60px !important;
+    }
+    
+    /* In case workspace indicator is not visible. */
+    @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
+        #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
+            max-height: calc(100% - 5px) !important;
+        }
+    }
+    
+    #zen-tabs-wrapper {
+        overflow: hidden !important;
+    }
+    
+    /* Ensure tab-groups never shrink. */
+    tab-group {
+        flex: 0 0 auto !important;
+    }
   }
 }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -350,7 +350,7 @@
             width: 18px !important;
         }
 
-        .tab-throbber[busy] {
+        .tab-throbber {
             transform: scale(1.125) !important;
         }
     }
@@ -365,7 +365,7 @@
             width: 20px !important;
         }
 
-        .tab-throbber[busy] {
+        .tab-throbber {
             transform: scale(1.25) !important;
         }
     }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -104,7 +104,7 @@
             }
 
             @media (-moz-bool-pref: "uc.pins.grid-count") {
-                /* Logic for pinned tabs that have auto-grow and grid-count. Must use +1 to fix bug. */
+                /* Logic for pinned tabs that have auto-grow and grid-count. Must use +1 to fix */
                 #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
                     width: calc(100% / (var(--mod-superpins-pins-grid-count) + 1)) !important;
                 }
@@ -374,6 +374,28 @@
   :root:has(#theme-SuperPins[uc-workspace-current-icon-size="large"]) {
       .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
           font-size: 16px !important;
+      }
+  }
+
+  /* prevents bottom portion of essentials element from being cut off. */
+  #zen-essentials-container {
+    padding: unset !important;
+  }
+
+  /* margin below essentials */
+  :root:has(#theme-Superpins[uc-essentials-bottom-margin="small"]) {
+      #zen-essentials-container {
+          margin-bottom: 3px !important;
+      }
+  }
+  :root:has(#theme-SuperPins[uc-essentials-bottom-margin="normal"]) {
+      #zen-essentials-container {
+          margin-bottom: 8px !important;
+      }
+  }
+  :root:has(#theme-SuperPins[uc-essentials-bottom-margin="large"]) {
+      #zen-essentials-container {
+          margin-bottom: 12px !important;
       }
   }
 

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -434,4 +434,10 @@
         text-decoration: line-through !important;
     }
   }
+
+  @media (-moz-bool-pref: "uc.tabs.always-show-separator") {
+    #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+        min-height: 20px !important;
+    }
+  }
 }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -95,27 +95,27 @@
 
         /*disable icon shift when tab was renamed*/
         #navigator-toolbox[zen-sidebar-expanded="true"] {
-            & #tabbrowser-tabs {
-                & .tabbrowser-tab {
-                    &[zen-pinned-changed="true"]:not([zen-essential])>.tab-stack>.tab-content>.tab-icon-stack {
-                        left: unset !important;
-                    }
-                }
+            & #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab>.tab-stack>.tab-content>.tab-icon-stack {
+                left: unset !important;
             }
         }
 
         /* Make pinned tabs auto-grow to span full width of row */
         @media (-moz-bool-pref: "uc.pins.auto-grow") {
-            #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
+            #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab {
                 width: auto !important;
                 min-width: var(--tab-pinned-min-width-expanded) !important;
                 flex: 1 1 auto !important;
             }
 
+            #vertical-pinned-tabs-container>.zen-workspace-tabs-section>tab-group {
+                width: 100% !important;
+            }
+
             @media (-moz-bool-pref: "uc.pins.grid-count") {
 
                 /* Logic for pinned tabs that have auto-grow and grid-count. Must use +1 to fix */
-                #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
+                #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab {
                     width: calc(100% / (var(--mod-superpins-pins-grid-count) + 1)) !important;
                 }
             }
@@ -149,12 +149,16 @@
             max-width: calc(100% - var(--zen-toolbox-padding) * 2) !important;
         }
 
-        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section .tabbrowser-tab {
             --toolbarbutton-inner-padding: 0;
         }
 
-        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>* {
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>*:not(tab-group) {
             margin: 0 !important;
+        }
+
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>tab-group .tab-icon-stack {
+            margin: auto !important;
         }
 
         .vertical-pinned-tabs-container-separator {
@@ -276,14 +280,14 @@
     }
 
     :root:has(#theme-SuperPins[uc-superpins-border="pins"]) {
-        .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-stack .tab-background {
+        .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-stack .tab-background, #vertical-pinned-tabs-container>.zen-workspace-tabs-section tab-group {
             border: 1px solid light-dark(color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
                     color-mix(in srgb, var(--zen-colors-secondary) 80%, white)) !important;
         }
     }
 
     :root:has(#theme-SuperPins[uc-superpins-border="both"]) {
-        .tabbrowser-tab[pinned] .tab-stack .tab-background {
+        .tabbrowser-tab[pinned] .tab-stack .tab-background, #vertical-pinned-tabs-container>.zen-workspace-tabs-section tab-group {
             border: 1px solid light-dark(color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
                     color-mix(in srgb, var(--zen-colors-secondary) 80%, white)) !important;
         }
@@ -301,7 +305,7 @@
             grid-template-columns: repeat(auto-fit, minmax(var(--essentials-width), auto)) !important;
         }
 
-        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab {
             min-width: var(--essentials-width) !important;
         }
 
@@ -314,20 +318,26 @@
 
     /* pins height */
     :root:has(#theme-SuperPins[uc-pinned-height="small"]) {
-        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(tab:not([hidden])) .tabbrowser-tab {
-            height: 40px !important;
+        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(> :nth-child(2)) .zen-workspace-tabs-section {
+            &>.tabbrowser-tab, &>tab-group {
+                height: 40px !important;
+            }
         }
     }
 
     :root:has(#theme-SuperPins[uc-pinned-height="normal"]) {
-        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(tab:not([hidden])) .tabbrowser-tab {
-            height: 50px !important;
+        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(> :nth-child(2)) .zen-workspace-tabs-section {
+            &>.tabbrowser-tab, &>tab-group {
+                height: 50px !important;
+            }
         }
     }
 
     :root:has(#theme-SuperPins[uc-pinned-height="large"]) {
-        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(tab:not([hidden])) .tabbrowser-tab {
-            height: 60px !important;
+        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(> :nth-child(2)) .zen-workspace-tabs-section {
+            &>.tabbrowser-tab, &>tab-group {
+                height: 60px !important;
+            }
         }
     }
 

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -104,8 +104,9 @@
             }
 
             @media (-moz-bool-pref: "uc.pins.grid-count") {
+                /* Logic for pinned tabs that have auto-grow and grid-count. Must use +1 to fix bug. */
                 #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
-                    width: calc(100% / var(--mod-superpins-pins-grid-count)) !important;
+                    width: calc(100% / (var(--mod-superpins-pins-grid-count) + 1)) !important;
                 }
             }
 
@@ -179,7 +180,7 @@
         @media (-moz-bool-pref: "uc.essentials.grid-count") {
             /* For auto-grow with grid-count. must use +1 to fix a bug */
             .tabbrowser-tab[zen-essential="true"] {
-                width: calc(100% / calc(var(--mod-superpins-essentials-grid-count) + 1)) !important;
+                width: calc(100% / (var(--mod-superpins-essentials-grid-count) + 1)) !important;
             }
         }
 

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -8,6 +8,11 @@
     }
 
     @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) {
+        /* Default essentials-width and essentials-gap variables (set to browser default) to fix some bugs */
+        :root {
+            --essentials-width: 49px;
+            --essentials-gap: calc(var(--zen-toolbox-padding) - 2px);
+        }
 
         /* Set width of Essentials (Dropdown) */
         :root:has(#theme-SuperPins[uc-essentials-width="Thin"]) {
@@ -29,6 +34,12 @@
                 grid-template-columns: repeat(auto-fit,
                         minmax(var(--essentials-width), auto)) !important;
                 min-width: var(--essentials-width) !important;
+            }
+
+            @media (-moz-bool-pref: "uc.essentials.grid-count") {
+                #zen-essentials-container {
+                    grid-template-columns: repeat(var(--mod-superpins-essentials-grid-count), minmax(var(--essentials-width), auto)) !important;
+                }
             }
         }
 
@@ -92,6 +103,12 @@
                 flex: 1 1 auto !important;
             }
 
+            @media (-moz-bool-pref: "uc.pins.grid-count") {
+                #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
+                    width: calc(100% / var(--mod-superpins-pins-grid-count)) !important;
+                }
+            }
+
             #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
                 display: flex !important;
                 flex-wrap: wrap !important;
@@ -103,6 +120,12 @@
             #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
                 grid-template-columns: repeat(auto-fit, minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
                 display: grid !important;
+            }
+
+            @media (-moz-bool-pref: "uc.pins.grid-count") {
+                #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+                    grid-template-columns: repeat(var(--mod-superpins-pins-grid-count), minmax(var(--tab-pinned-min-width-expanded), auto)) !important;
+                }
             }
         }
 
@@ -138,22 +161,32 @@
         }
     }
 
+    /* If Essentials have a grid count but do not have auto-grow on */
+    @media (-moz-bool-pref: "uc.essentials.grid-count") {
+        #zen-essentials-container {
+            grid-template-columns: repeat(var(--mod-superpins-essentials-grid-count), minmax(var(--essentials-width), auto)) !important;
+        }
+    }
+
     /* Make Essentials auto-grow to span full width of a row */
     @media (-moz-bool-pref: "uc.essentials.auto-grow") {
         .tabbrowser-tab[zen-essential="true"] {
             width: auto !important;
             min-width: var(--essentials-width) !important;
-            flex: 1 1 0 !important;
-            box-sizing: border-box !important;
+            flex: 1 1 auto !important;
+        }
+
+        @media (-moz-bool-pref: "uc.essentials.grid-count") {
+            /* For auto-grow with grid-count. must use +1 to fix a bug */
+            .tabbrowser-tab[zen-essential="true"] {
+                width: calc(100% / calc(var(--mod-superpins-essentials-grid-count) + 1)) !important;
+            }
         }
 
         #zen-essentials-container {
             display: flex !important;
             flex-wrap: wrap !important;
             flex-direction: row !important;
-            box-sizing: border-box !important;
-            min-width: 0 !important;
-            height: auto !important;
             width: 100% !important;
         }
 
@@ -233,14 +266,23 @@
 
     /* Let pinned tabs have the same selected styling as essentials */
     @media (-moz-bool-pref: "uc.pins.essentials-layout") {
-        #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
-            grid-template-columns: repeat(auto-fit,
-                    minmax(var(--essentials-width), auto)) !important;
+        /* Specific query to overwrite previous one */
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section:has(> :nth-child(2)) {
             gap: var(--essentials-gap) var(--essentials-gap) !important;
+        }
+
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+            grid-template-columns: repeat(auto-fit, minmax(var(--essentials-width), auto)) !important;
         }
 
         #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
             min-width: var(--essentials-width) !important;
+        }
+
+        @media (-moz-bool-pref: "uc.pins.grid-count") {
+            #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+                grid-template-columns: repeat(var(--mod-superpins-pins-grid-count), minmax(var(--essentials-width), auto)) !important;
+            }
         }
     }
     /* pins height */
@@ -333,7 +375,7 @@
           font-size: 16px !important;
       }
   }
-    
+
   /* Ensure that the browser uses SuperPins dim rather than the built-in dim-pending. */
   .tab-icon-image[pending="true"], .tabbrowser-tab[pending="true"] .tab-text {
     opacity: 1 !important;
@@ -358,5 +400,11 @@
     .tab-icon-image[pending="true"], .tabbrowser-tab[pending="true"] .tab-text {
       opacity: 0.5 !important;
     }
-  } 
+  }
+
+  @media (-moz-bool-pref: "uc.tabs.strikethrough-on-pending") {
+    .tabbrowser-tab[pending="true"] .tab-text {
+        text-decoration: line-through !important;
+    }
+  }
 }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -157,6 +157,16 @@
             transform: translateX(-50%) !important;
             width: calc(100% - var(--zen-toolbox-padding) * 2) !important;
         }
+
+        :root:has(#theme-SuperPins[uc-tabs-show-separator="never"]) {
+            .vertical-pinned-tabs-container-separator {
+                display: none !important;
+            }
+
+            #vertical-pinned-tabs-container>.zen-workspace-tabs-section:has(> :nth-child(2)) {
+                padding-bottom: 5px !important;
+            }
+        }
     }
 
     /* Make Essentials look more box like */
@@ -435,7 +445,7 @@
     }
   }
 
-  @media (-moz-bool-pref: "uc.tabs.always-show-separator") {
+  :root:has(#theme-SuperPins[uc-tabs-show-separator="always"]) {
     #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
         min-height: 20px !important;
     }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -451,4 +451,38 @@
         min-height: 20px !important;
     }
   }
+
+  @media (-moz-bool-pref: "uc.pins.stay-at-top") {
+      #zen-browser-tabs-container {
+          height: 100% !important;
+      }
+      
+      #tabbrowser-arrowscrollbox {
+          height: 100% !important;
+      }
+      
+      #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
+          overflow-y: auto !important;
+          /* Calculate the height of the bottom workspace section. */
+          max-height: calc(100% - 43px) !important;
+          box-sizing: border-box !important;
+          padding-bottom: 60px !important;
+      }
+      
+      /* In case workspace indicator is not visible. */
+      @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
+          #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
+              max-height: calc(100% - 5px) !important;
+          }
+      }
+      
+      #zen-tabs-wrapper {
+          overflow: hidden !important;
+      }
+      
+      /* Ensure tab-groups never shrink. */
+      tab-group {
+          flex: 0 0 auto !important;
+      }
+  }
 }

--- a/SuperPins/SuperPins.css
+++ b/SuperPins/SuperPins.css
@@ -1,9 +1,10 @@
 @media (-moz-bool-pref: "zen.tabs.vertical") {
+
     /* Prevents stuff from being clipped off from bottom of Essentials */
     #zen-essentials-container {
         overflow: visible !important;
     }
-    
+
     /* Makes essentials transparent (when toggled) */
     :root:has(#theme-SuperPins[uc-essentials-color-scheme="transparent"]) {
         .tabbrowser-tab[zen-essential="true"]:not(:hover):not([selected="true"]) .tab-stack .tab-background {
@@ -12,6 +13,7 @@
     }
 
     @media (-moz-bool-pref: "zen.view.sidebar-expanded") and (not (-moz-bool-pref: "zen.view.sidebar-expanded.on-hover")) {
+
         /* Default essentials-width and essentials-gap variables (set to browser default) to fix some bugs */
         :root {
             --essentials-width: 49px;
@@ -108,6 +110,7 @@
             }
 
             @media (-moz-bool-pref: "uc.pins.grid-count") {
+
                 /* Logic for pinned tabs that have auto-grow and grid-count. Must use +1 to fix */
                 #vertical-pinned-tabs-container>.zen-workspace-tabs-section>.tabbrowser-tab[pinned] {
                     width: calc(100% / (var(--mod-superpins-pins-grid-count) + 1)) !important;
@@ -147,7 +150,7 @@
             --toolbarbutton-inner-padding: 0;
         }
 
-        #vertical-pinned-tabs-container > .zen-workspace-tabs-section > * {
+        #vertical-pinned-tabs-container>.zen-workspace-tabs-section>* {
             margin: 0 !important;
         }
 
@@ -193,6 +196,7 @@
         }
 
         @media (-moz-bool-pref: "uc.essentials.grid-count") {
+
             /* For auto-grow with grid-count. must use +1 to fix a bug */
             .tabbrowser-tab[zen-essential="true"] {
                 width: calc(100% / (var(--mod-superpins-essentials-grid-count) + 1)) !important;
@@ -282,6 +286,7 @@
 
     /* Let pinned tabs have the same selected styling as essentials */
     @media (-moz-bool-pref: "uc.pins.essentials-layout") {
+
         /* Specific query to overwrite previous one */
         #vertical-pinned-tabs-container>.zen-workspace-tabs-section:has(> :nth-child(2)) {
             gap: var(--essentials-gap) var(--essentials-gap) !important;
@@ -301,189 +306,202 @@
             }
         }
     }
+
     /* pins height */
-  :root:has(#theme-SuperPins[uc-pinned-height="small"]) {
-      #navigator-toolbox[zen-sidebar-expanded="true"]
-          #vertical-pinned-tabs-container:has(tab:not([hidden]))
-          .tabbrowser-tab {
-          height: 40px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-pinned-height="normal"]) {
-      #navigator-toolbox[zen-sidebar-expanded="true"]
-          #vertical-pinned-tabs-container:has(tab:not([hidden]))
-          .tabbrowser-tab {
-          height: 50px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-pinned-height="large"]) {
-      #navigator-toolbox[zen-sidebar-expanded="true"]
-          #vertical-pinned-tabs-container:has(tab:not([hidden]))
-          .tabbrowser-tab {
-          height: 60px !important;
-      }
-  }
-  /* favicon size */
-  :root:has(#theme-SuperPins[uc-favicon-size="small"]) {
-      .tab-throbber,
-      .tab-icon-pending,
-      .tab-icon-image,
-      .tab-sharing-icon-overlay,
-      .tab-icon-overlay {
-          height: 16px !important;
-          width: 16px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-favicon-size="normal"]) {
-      .tab-throbber,
-      .tab-icon-pending,
-      .tab-icon-image,
-      .tab-sharing-icon-overlay,
-      .tab-icon-overlay {
-          height: 18px !important;
-          width: 18px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-favicon-size="large"]) {
-      .tab-throbber,
-      .tab-icon-pending,
-      .tab-icon-image,
-      .tab-sharing-icon-overlay,
-      .tab-icon-overlay {
-          height: 20px !important;
-          width: 20px !important;
-      }
-  }
-  /* workspace icons size */
-  :root:has(#theme-SuperPins[uc-workspace-icon-size="x-small"]) {
-      #zen-workspaces-button {
-          font-size: x-small !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-workspace-icon-size="small"]) {
-      #zen-workspaces-button {
-          font-size: small !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-workspace-icon-size="medium"]) {
-      #zen-workspaces-button {
-          font-size: medium !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-workspace-icon-size="large"]) {
-      #zen-workspaces-button {
-          font-size: large !important;
-      }
-  }
-  /* current workspace icons size */
-  :root:has(#theme-SuperPins[uc-workspace-current-icon-size="small"]) {
-      .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
-          font-size: 12px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-workspace-current-icon-size="normal"]) {
-      .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
-          font-size: 14.5px !important;
-      }
-  }
-  :root:has(#theme-SuperPins[uc-workspace-current-icon-size="large"]) {
-      .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
-          font-size: 16px !important;
-      }
-  }
-
-  /* prevents bottom portion of essentials element from being cut off. */
-  #zen-essentials-container {
-    padding: unset !important;
-  }
-
-  /* Increase margin below Essentials in case the workspace indicator is not visible. */
-  @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
-      :root:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"]) {
-          #zen-essentials-container:has(~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container .zen-workspace-tabs-section[active="true"] .tabbrowser-tab) {
-              margin-bottom: 8px !important;
-          }
-
-          #zen-essentials-container:has(> :nth-child(1)) ~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
-              min-height: 20px !important;
-          }
-
-          #zen-essentials-container:has(> :nth-child(1)) ~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section .vertical-pinned-tabs-container-separator {
-              max-height: unset !important;
-          }
-      }
-
-      :root:not(:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"])) {
-          #zen-essentials-container {
-              margin-bottom: 8px !important;
-          }
-      }
-  }
-
-  /* Ensure that the browser uses SuperPins dim rather than the built-in dim-pending. */
-  .tab-icon-image[pending="true"], .tabbrowser-tab[pending="true"] .tab-text {
-    opacity: 1 !important;
-  }
-
-  /* If dim-type is set to icons. */
-  :root:has(#theme-SuperPins[uc-tabs-dim-type="icons"]) {
-    .tab-icon-image[pending="true"] {
-      opacity: 0.5 !important;
-    }
-  }
-
-  /* If dim-type is set to text. */
-  :root:has(#theme-SuperPins[uc-tabs-dim-type="text"]) {
-    .tabbrowser-tab[pending="true"] .tab-text {
-      opacity: 0.5 !important;
-    }
-  }
-
-  /* If dim-type is set to icon + text. */
-  :root:has(#theme-SuperPins[uc-tabs-dim-type="both"]) {
-    .tab-icon-image[pending="true"], .tabbrowser-tab[pending="true"] .tab-text {
-      opacity: 0.5 !important;
-    }
-  }
-
-  @media (-moz-bool-pref: "uc.tabs.strikethrough-on-pending") {
-    .tabbrowser-tab[pending="true"] .tab-text {
-        text-decoration: line-through !important;
-    }
-  }
-
-  @media (-moz-bool-pref: "uc.pins.stay-at-top") {
-    #zen-browser-tabs-container {
-        height: 100% !important;
-    }
-    
-    #tabbrowser-arrowscrollbox {
-        height: 100% !important;
-    }
-    
-    #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
-        overflow-y: auto !important;
-        overflow-x: hidden !important;
-        /* Calculate the height of the bottom workspace section. */
-        max-height: calc(100% - 43px) !important;
-        box-sizing: border-box !important;
-        padding-bottom: 60px !important;
-    }
-    
-    /* In case workspace indicator is not visible. */
-    @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
-        #tabbrowser-arrowscrollbox > .zen-workspace-tabs-section {
-            max-height: calc(100% - 5px) !important;
+    :root:has(#theme-SuperPins[uc-pinned-height="small"]) {
+        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(tab:not([hidden])) .tabbrowser-tab {
+            height: 40px !important;
         }
     }
-    
-    #zen-tabs-wrapper {
-        overflow: hidden !important;
+
+    :root:has(#theme-SuperPins[uc-pinned-height="normal"]) {
+        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(tab:not([hidden])) .tabbrowser-tab {
+            height: 50px !important;
+        }
     }
-    
-    /* Ensure tab-groups never shrink. */
-    tab-group {
-        flex: 0 0 auto !important;
+
+    :root:has(#theme-SuperPins[uc-pinned-height="large"]) {
+        #navigator-toolbox[zen-sidebar-expanded="true"] #vertical-pinned-tabs-container:has(tab:not([hidden])) .tabbrowser-tab {
+            height: 60px !important;
+        }
     }
-  }
+
+    /* favicon size */
+    :root:has(#theme-SuperPins[uc-favicon-size="small"]) {
+
+        .tab-throbber,
+        .tab-icon-pending,
+        .tab-icon-image,
+        .tab-sharing-icon-overlay,
+        .tab-icon-overlay {
+            height: 16px !important;
+            width: 16px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-favicon-size="normal"]) {
+
+        .tab-throbber,
+        .tab-icon-pending,
+        .tab-icon-image,
+        .tab-sharing-icon-overlay,
+        .tab-icon-overlay {
+            height: 18px !important;
+            width: 18px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-favicon-size="large"]) {
+
+        .tab-throbber,
+        .tab-icon-pending,
+        .tab-icon-image,
+        .tab-sharing-icon-overlay,
+        .tab-icon-overlay {
+            height: 20px !important;
+            width: 20px !important;
+        }
+    }
+
+    /* workspace icons size */
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="x-small"]) {
+        #zen-workspaces-button {
+            font-size: x-small !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="small"]) {
+        #zen-workspaces-button {
+            font-size: small !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="medium"]) {
+        #zen-workspaces-button {
+            font-size: medium !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-icon-size="large"]) {
+        #zen-workspaces-button {
+            font-size: large !important;
+        }
+    }
+
+    /* current workspace icons size */
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="small"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 12px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="normal"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 14.5px !important;
+        }
+    }
+
+    :root:has(#theme-SuperPins[uc-workspace-current-icon-size="large"]) {
+        .zen-current-workspace-indicator .zen-current-workspace-indicator-icon {
+            font-size: 16px !important;
+        }
+    }
+
+    /* prevents bottom portion of essentials element from being cut off. */
+    #zen-essentials-container {
+        padding: unset !important;
+    }
+
+    /* Increase margin below Essentials in case the workspace indicator is not visible. */
+    @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
+        :root:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"]) {
+            #zen-essentials-container:has(~ #zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container .zen-workspace-tabs-section[active="true"] .tabbrowser-tab) {
+                margin-bottom: 8px !important;
+            }
+
+            #zen-essentials-container:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section {
+                min-height: 20px !important;
+            }
+
+            #zen-essentials-container:has(> :nth-child(1))~#zen-tabs-wrapper #zen-browser-tabs-container #vertical-pinned-tabs-container>.zen-workspace-tabs-section .vertical-pinned-tabs-container-separator {
+                max-height: unset !important;
+            }
+        }
+
+        :root:not(:has(#theme-SuperPins[uc-tabs-show-separator="essentials-shown"])) {
+            #zen-essentials-container {
+                margin-bottom: 8px !important;
+            }
+        }
+    }
+
+    /* Ensure that the browser uses SuperPins dim rather than the built-in dim-pending. */
+    .tab-icon-image[pending="true"],
+    .tabbrowser-tab[pending="true"] .tab-text {
+        opacity: 1 !important;
+    }
+
+    /* If dim-type is set to icons. */
+    :root:has(#theme-SuperPins[uc-tabs-dim-type="icons"]) {
+        .tab-icon-image[pending="true"] {
+            opacity: 0.5 !important;
+        }
+    }
+
+    /* If dim-type is set to text. */
+    :root:has(#theme-SuperPins[uc-tabs-dim-type="text"]) {
+        .tabbrowser-tab[pending="true"] .tab-text {
+            opacity: 0.5 !important;
+        }
+    }
+
+    /* If dim-type is set to icon + text. */
+    :root:has(#theme-SuperPins[uc-tabs-dim-type="both"]) {
+
+        .tab-icon-image[pending="true"],
+        .tabbrowser-tab[pending="true"] .tab-text {
+            opacity: 0.5 !important;
+        }
+    }
+
+    @media (-moz-bool-pref: "uc.tabs.strikethrough-on-pending") {
+        .tabbrowser-tab[pending="true"] .tab-text {
+            text-decoration: line-through !important;
+        }
+    }
+
+    @media (-moz-bool-pref: "uc.pins.stay-at-top") {
+        #zen-browser-tabs-container {
+            height: 100% !important;
+        }
+
+        #tabbrowser-arrowscrollbox {
+            height: 100% !important;
+        }
+
+        #tabbrowser-arrowscrollbox>.zen-workspace-tabs-section {
+            overflow-y: auto !important;
+            overflow-x: hidden !important;
+            /* Calculate the height of the bottom workspace section. */
+            max-height: calc(100% - 43px) !important;
+            box-sizing: border-box !important;
+            padding-bottom: 60px !important;
+        }
+
+        /* In case workspace indicator is not visible. */
+        @media (not (-moz-bool-pref: "zen.workspaces.show-workspace-indicator")) {
+            #tabbrowser-arrowscrollbox>.zen-workspace-tabs-section {
+                max-height: calc(100% - 5px) !important;
+            }
+        }
+
+        #zen-tabs-wrapper {
+            overflow: hidden !important;
+        }
+
+        /* Ensure tab-groups never shrink. */
+        tab-group {
+            flex: 0 0 auto !important;
+        }
+    }
 }

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -249,6 +249,26 @@
         ]
     },
     {
+        "property": "uc.essentials.bottom-margin",
+        "label": "Margin below Essentials",
+        "type": "dropdown",
+        "placeholder": "Default",
+        "options": [
+            {
+                "label": "Small",
+                "value": "small"
+            },
+            {
+                "label": "Normal",
+                "value": "normal"
+            },
+            {
+                "label": "Large",
+                "value": "large"
+            }
+        ]
+    },
+    {
         "property": "uc.essentials.grid-count",
         "label": "Makes Essentials have a limited amount of columns",
         "type": "checkbox",

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -145,6 +145,12 @@
         "disabledOn": []
     },
     {
+        "property": "uc.tabs.always-show-separator",
+        "label": "Always show separator",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "uc.tabs.dim-type",
         "label": "Dim the selected parts of a tab when it is unloaded",
         "type": "dropdown",

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -139,6 +139,12 @@
         "disabledOn": []
     },
     {
+        "property": "uc.tabs.strikethrough-on-pending",
+        "label": "Adds a strikethrough effect on unloaded tabs",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "uc.tabs.dim-type",
         "label": "Dim the selected parts of a tab when it is unloaded",
         "type": "dropdown",
@@ -243,15 +249,29 @@
         ]
     },
     {
+        "property": "uc.essentials.grid-count",
+        "label": "Makes Essentials have a limited amount of columns",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "mod.superpins.essentials.grid-count",
         "label": "Number of slots in essentials grid.",
         "type": "string",
+        "disabledOn": [],
+        "defaultValue": "1"
+    },
+    {
+        "property": "uc.pins.grid-count",
+        "label": "Makes pinned tabs have a limited amount of columns",
+        "type": "checkbox",
         "disabledOn": []
     },
     {
         "property": "mod.superpins.pins.grid-count",
         "label": "Number of slots in pins grid.",
         "type": "string",
-        "disabledOn": []
+        "disabledOn": [],
+        "defaultValue": "1"
     }
 ]

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -145,10 +145,26 @@
         "disabledOn": []
     },
     {
-        "property": "uc.tabs.always-show-separator",
-        "label": "Always show separator",
-        "type": "checkbox",
-        "disabledOn": []
+        "property": "uc.tabs.show-separator",
+        "label": "When to display separator",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Default",
+        "defaultValue": "sometimes",
+        "options": [
+            {
+                "label": "Never",
+                "value": "never"
+            },
+            {
+                "label": "Sometimes",
+                "value": "sometimes"
+            },
+            {
+                "label": "Always",
+                "value": "always"
+            }
+        ]
     },
     {
         "property": "uc.tabs.dim-type",

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -145,12 +145,6 @@
         "disabledOn": []
     },
     {
-        "property": "uc.tabs.strikethrough-on-pending",
-        "label": "Adds a strikethrough effect on unloaded tabs",
-        "type": "checkbox",
-        "disabledOn": []
-    },
-    {
         "property": "uc.tabs.show-separator",
         "label": "When to display separator",
         "type": "dropdown",
@@ -191,6 +185,12 @@
                 "value": "text"
             }
         ]
+    },
+    {
+        "property": "uc.tabs.strikethrough-on-pending",
+        "label": "Adds a strikethrough effect on unloaded tabs",
+        "type": "checkbox",
+        "disabledOn": []
     },
     {
         "property": "uc.pinned.height",

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -241,5 +241,17 @@
                 "value": "large"
             }
         ]
+    },
+    {
+        "property": "mod.superpins.essentials.grid-count",
+        "label": "Number of slots in essentials grid.",
+        "type": "string",
+        "disabledOn": []
+    },
+    {
+        "property": "mod.superpins.pins.grid-count",
+        "label": "Number of slots in pins grid.",
+        "type": "string",
+        "disabledOn": []
     }
 ]

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -145,6 +145,18 @@
         "disabledOn": []
     },
     {
+        "property": "uc.pins.active-bg",
+        "label": "Adds a custom background to active pinned tabs",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
+        "property": "mod.superpins.pins.active-bg",
+        "label": "Custom background for active pinned tabs.",
+        "type": "string",
+        "disabledOn": []
+    },
+    {
         "property": "uc.tabs.strikethrough-on-pending",
         "label": "Adds a strikethrough effect on unloaded tabs",
         "type": "checkbox",

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -139,6 +139,12 @@
         "disabledOn": []
     },
     {
+        "property": "uc.pins.stay-at-top",
+        "label": "Keep pinned tabs at the top when scrolling",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "uc.tabs.strikethrough-on-pending",
         "label": "Adds a strikethrough effect on unloaded tabs",
         "type": "checkbox",

--- a/SuperPins/preferences.json
+++ b/SuperPins/preferences.json
@@ -145,24 +145,30 @@
         "disabledOn": []
     },
     {
+        "property": "uc.tabs.strikethrough-on-pending",
+        "label": "Adds a strikethrough effect on unloaded tabs",
+        "type": "checkbox",
+        "disabledOn": []
+    },
+    {
         "property": "uc.tabs.show-separator",
         "label": "When to display separator",
         "type": "dropdown",
         "disabledOn": [],
         "placeholder": "Default",
-        "defaultValue": "sometimes",
+        "defaultValue": "pinned-shown",
         "options": [
             {
                 "label": "Never",
                 "value": "never"
             },
             {
-                "label": "Sometimes",
-                "value": "sometimes"
+                "label": "When there are pinned tabs only",
+                "value": "pinned-shown"
             },
             {
-                "label": "Always",
-                "value": "always"
+                "label": "When there are Essentials and/or pinned tabs",
+                "value": "essentials-shown"
             }
         ]
     },
@@ -185,12 +191,6 @@
                 "value": "text"
             }
         ]
-    },
-    {
-        "property": "uc.tabs.strikethrough-on-pending",
-        "label": "Adds a strikethrough effect on unloaded tabs",
-        "type": "checkbox",
-        "disabledOn": []
     },
     {
         "property": "uc.pinned.height",
@@ -259,26 +259,6 @@
     {
         "property": "uc.workspace.current.icon.size",
         "label": "Size of current workspace indicator icon",
-        "type": "dropdown",
-        "placeholder": "Default",
-        "options": [
-            {
-                "label": "Small",
-                "value": "small"
-            },
-            {
-                "label": "Normal",
-                "value": "normal"
-            },
-            {
-                "label": "Large",
-                "value": "large"
-            }
-        ]
-    },
-    {
-        "property": "uc.essentials.bottom-margin",
-        "label": "Margin below Essentials",
         "type": "dropdown",
         "placeholder": "Default",
         "options": [

--- a/SuperPins/theme.json
+++ b/SuperPins/theme.json
@@ -2,12 +2,12 @@
     "id": "ad97bb70-0066-4e42-9b5f-173a5e42c6fc",
     "name": "SuperPins",
     "description": "This Zen Mod enhances pinned tabs/Essentials, by making some UI/UX changes.",
-    "homepage": "https://github.com/JLBlk/Zen-Themes/tree/main/SuperPins",
+    "homepage": "https://github.com/CosmoCreeper/Zen-Themes/tree/main/SuperPins",
     "style": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/chrome.css",
     "readme": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/readme.md",
     "image": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/image.png",
-    "author": "JLBlk",
-    "version": "1.5.0",
+    "author": "CosmoCreeper",
+    "version": "1.5.1",
     "preferences": "https://raw.githubusercontent.com/zen-browser/theme-store/main/themes/ad97bb70-0066-4e42-9b5f-173a5e42c6fc/preferences.json",
     "tags": [
         "tabs"

--- a/SuperUrlBar/SuperUrlBar.css
+++ b/SuperUrlBar/SuperUrlBar.css
@@ -10,7 +10,7 @@
         
   /* Border radius on hover */
   #urlbar .urlbar-page-action, #urlbar #tracking-protection-icon-container, #urlbar:not([breakout-extend="true"]) #identity-box:is(:not(.chromeUI), [pageproxystate="invalid"]) #identity-icon-box {
-    border-radius: 20px !important;;
+    border-radius: 20px !important;
   }
         
   /* Border radius of boxes on the left */
@@ -123,8 +123,9 @@
 
 /* Adds a border to the url bar when toggled */
 @media (-moz-bool-pref: "uc.urlbar.border") {
-  #urlbar {
-    border: 1px solid var(--zen-colors-border) !important;
+  #urlbar-background {
+    border: 1px solid light-dark(color-mix(in srgb, var(--zen-colors-secondary) 80%, black),
+                    color-mix(in srgb, var(--zen-colors-secondary) 80%, white)) !important;
   }
 }
 

--- a/SuperUrlBar/SuperUrlBar.css
+++ b/SuperUrlBar/SuperUrlBar.css
@@ -1,30 +1,35 @@
 /* Adjust border radius of url bar and its elements */
-@media (-moz-bool-pref: "uc.urlbar.border-radius") {
-  #urlbar {
-    border-radius: 20px !important;
-  }
-          
-  #notification-popup-box {
-    border-radius: 20px !important;
-  }
-        
-  /* Border radius on hover */
-  #urlbar .urlbar-page-action, #urlbar #tracking-protection-icon-container, #urlbar:not([breakout-extend="true"]) #identity-box:is(:not(.chromeUI), [pageproxystate="invalid"]) #identity-icon-box {
-    border-radius: 20px !important;
-  }
-        
-  /* Border radius of boxes on the left */
-  #identity-box:has(#identity-permission-box:is([hasPermissions], [hasSharingIcon])):not([pageproxystate="invalid"]) #identity-icon-box {
-    border-top-left-radius: 20px !important;
-    border-bottom-left-radius: 20px !important;
-    border-top-right-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
-  }
+:root:has(#theme-Super-Url-Bar[uc-urlbar-border-radius="small"]) {
+  --urlbar-border-radius: 4px;
+}
+:root:has(#theme-Super-Url-Bar[uc-urlbar-border-radius="medium"]) {
+  --urlbar-border-radius: 8px;
+}
+:root:has(#theme-Super-Url-Bar[uc-urlbar-border-radius="large"]) {
+  --urlbar-border-radius: 14px;
+}
+:root:has(#theme-Super-Url-Bar[uc-urlbar-border-radius="xlarge"]) {
+  --urlbar-border-radius: 20px;
+}
 
-  /* Extensions or similar */
-  #urlbar:not([breakout-extend="true"]) #identity-box.chromeUI:not([pageproxystate="invalid"]) #identity-icon-box {
-    border-radius: 20px 20px 20px 20px !important;
-  }
+:root:has(#theme-Super-Url-Bar[uc-urlbar-border-radius="small"],
+          #theme-Super-Url-Bar[uc-urlbar-border-radius="medium"],
+          #theme-Super-Url-Bar[uc-urlbar-border-radius="large"],
+          #theme-Super-Url-Bar[uc-urlbar-border-radius="xlarge"]) {
+    #urlbar, #urlbar-background, #notification-popup-box, #urlbar .urlbar-page-action, #urlbar #tracking-protection-icon-container,
+    #urlbar:not([breakout-extend="true"]) #identity-box:is(:not(.chromeUI), [pageproxystate="invalid"]) #identity-icon-box,
+    #urlbar:not([breakout-extend="true"]) #identity-box.chromeUI:not([pageproxystate="invalid"]) #identity-icon-box,
+    .identity-box-button {
+      border-radius: var(--urlbar-border-radius) !important;
+    }
+          
+    /* Border radius of boxes on the left */
+    #identity-box:has(#identity-permission-box:is([hasPermissions], [hasSharingIcon])):not([pageproxystate="invalid"]) #identity-icon-box {
+      border-top-left-radius: var(--urlbar-border-radius) !important;
+      border-bottom-left-radius: var(--urlbar-border-radius) !important;
+      border-top-right-radius: 0 !important;
+      border-bottom-right-radius: 0 !important;
+    }
 }
 
 /* Centers the url text when enabled in dropdown: 1.Option: Centers the text unless url bar is focused; 2.Option: Centers the text always*/

--- a/SuperUrlBar/SuperUrlBar.css
+++ b/SuperUrlBar/SuperUrlBar.css
@@ -167,102 +167,79 @@
 
   @media (-moz-bool-pref: "uc.urlbar.icon.zoom.removed") {
     #urlbar:hover #urlbar-zoom-button {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     } 
   }
   @media (-moz-bool-pref: "uc.urlbar.icon.shield.removed") {
     #urlbar:hover #tracking-protection-icon-container, #tracking-protection-icon-container[open="true"] {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     } 
   }
   @media (-moz-bool-pref: "uc.urlbar.icon.bookmark.removed") {
     #urlbar:hover #star-button-box, #star-button-box[open="true"] {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     } 
   }
   @media (-moz-bool-pref: "uc.urlbar.icon.reader-mode.removed") {
     #urlbar:hover #reader-mode-button {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     } 
   }
   @media (-moz-bool-pref: "uc.urlbar.icon.pip.removed") {
     #urlbar:hover #picture-in-picture-button {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     } 
   }
   @media (-moz-bool-pref: "uc.urlbar.icon.split-view.removed") {
     #urlbar:hover #zen-split-views-box {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     }
   }
   @media (-moz-bool-pref: "uc.urlbar.icon.left-side.removed") {
     #urlbar:hover #identity-box {
-      position: relative;
-      opacity: 1;
+      display: block !important;
     } 
   }
+}
+
+/* Brings back the tracking protection icon */
+#urlbar[open] #tracking-protection-icon-container {
+  display: block !important;
 }
 
 /* Removes certain buttons from the url bar (when toggled) */
 @media (-moz-bool-pref: "uc.urlbar.icon.zoom.removed") {
   #urlbar-zoom-button {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.shield.removed") {
   #tracking-protection-icon-container {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.bookmark.removed") {
   #star-button-box {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.reader-mode.removed") {
   #reader-mode-button {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.pip.removed") {
   #picture-in-picture-button {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.split-view.removed") {
   #zen-split-views-box {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }
 @media (-moz-bool-pref: "uc.urlbar.icon.left-side.removed") {
   #identity-box {
-    opacity: 0;
-    pointer-events: var(--pointer-events) !important;
-    position: var(--position-var);
-    transition: 100ms linear, opacity 200ms linear;
+    display: none !important;
   }
 }

--- a/SuperUrlBar/SuperUrlBar.css
+++ b/SuperUrlBar/SuperUrlBar.css
@@ -80,10 +80,10 @@
     pointer-events: none;
   
     width: 200vw;
-    height: 100vh;
+    height: 200vh;
   
-    top: 0px;
-    left: -50px;
+    top: -100vh;
+    left: -100vw;
   
     background-color: rgba(0, 0, 0, 0.3);
     backdrop-filter: blur(var(--blur-intensity));

--- a/SuperUrlBar/preferences.json
+++ b/SuperUrlBar/preferences.json
@@ -1,9 +1,27 @@
 [
     {
         "property": "uc.urlbar.border-radius",
-        "label": "Adjusts the border radius of the url bar and its items",
-        "type": "checkbox",
-        "disabledOn": []
+        "label": "Adjusts the border radius of the url bar and its items to a certain degree",
+        "type": "dropdown",
+        "disabledOn": [],
+        "options": [
+            {
+                "label": "Small",
+                "value": "small"
+            },
+            {
+                "label": "Medium",
+                "value": "medium"
+            },
+            {
+                "label": "Large",
+                "value": "large"
+            },
+            {
+                "label": "Extra Large",
+                "value": "xlarge"
+            }
+        ]
     },
     {
         "property": "uc.urltext.center",


### PR DESCRIPTION
In this pull request, I added the option to have a line-through effect on unloaded tabs (#92), I implemented the ability to have custom grid sizes for Essentials and Pinned Tabs (#86), I added  extra margin below Essentials when the workspace indicator is not visible (#87), I also added a dropdown for which occasions to show the separator, I added an option to keep all pinned tabs at the top when scrolling normal tabs (#76), I fixed issues with the zen-essentials-container styling on Twilight (#99), fixed split tabs not displaying correctly when they were pinned tabs and the auto-grow feature was enabled (#98), and I fixed a couple of edge cases when Essentials width and gap settings were set to "Zen Default".

<img src="https://github.com/user-attachments/assets/412c4d70-61d1-456a-ab2e-851eca025427" width="300">

EDIT: I originally noted a bug here but I removed it because it is fixed! I also deleted and edited a couple of comments below that mentioned bugs that are now fixed in order to make it easier to follow along with the updates.

I am also working on improving Super URL Bar by modernizing code to be compatible with newer versions of Zen.